### PR TITLE
Add as_oof init param

### DIFF
--- a/src/autogluon/fair/learners/fair.py
+++ b/src/autogluon/fair/learners/fair.py
@@ -27,6 +27,11 @@ class FairPredictor:
         2. a vector of the same size as the validation set containing discrete values
         3. The value None   (used when we don't require groups, for example,
                if we are optimizing F1 without per-group thresholds)
+    as_oof : bool, default = False
+        If True, `validation_data` should be the original training data used to fit `predictor`.
+        If False, `validation_data` should be holdout data that was not used during the fit call of `predictor`, or was specified as `tuning_data`.
+        When True, this allows the predictor to directly fetch the proper prediction probabilities using out-of-fold predictions.
+        This is optimal, and should always be set to True unless the user is providing new unseen data to `validation_data`.
     inferred_groups: (Optional, default False) A binary or multiclass autogluon predictor that infers the protected
                                 attributes.
         This can be used to enforce fairness when no information about protected attribtutes is
@@ -38,9 +43,14 @@ class FairPredictor:
     If use_fast is False, autogluon scorers are also supported.
     """
 
-    def __init__(self, predictor, validation_data, groups=None, *, inferred_groups=False,
-                 use_fast=True) -> None:
-
+    def __init__(self,
+                 predictor,
+                 validation_data,
+                 groups=None,
+                 *,
+                 as_oof: bool = False,
+                 inferred_groups=False,
+                 use_fast=True):
         if predictor.problem_type != 'binary':
             logger.error('Fairpredictor only takes a binary predictor as input')
         self.predictor = predictor
@@ -52,8 +62,24 @@ class FairPredictor:
         # However, as a user interface groups = None makes more sense for instantiation.
         self.groups = groups
         self.use_fast: bool = use_fast
-        self.validation_data = validation_data
+
+        # TODO: Next step to make this easier is to cache original train data during TabularPredictor.fit
+        #  so we can load it here without the user needing to even pass validation_data at all.
+        #  This would maximize ease of use.
+        #  This requires adding new logic to TabularPredictor.
+        if as_oof:
+            model_best = predictor.get_model_best()
+            y_pred_proba = predictor.predict_proba_multi(inverse_transform=True, models=[model_best])[model_best]
+            val_data_source = 'val' if predictor._trainer.has_val else 'train'
+            _, y_val = predictor.load_data_internal(data=val_data_source, return_X=False, return_y=True)
+            self.validation_data = validation_data.loc[y_val.index]  # FIXME: Store true data directly in predictor
+        else:
+            self.validation_data = validation_data
+            y_pred_proba = predictor.predict_proba(self.validation_data)
+
         validation_labels = self.validation_data[predictor.label]
+
+        self.proba = np.asarray(y_pred_proba)
 
         # We use _internal_groups as a standardized argument that is always safe to pass
         # to functions expecting a vector
@@ -64,6 +90,9 @@ class FairPredictor:
 
         self.inferred_groups: bool = inferred_groups
         if inferred_groups:
+            # FIXME: Not implemented correctly when `as_oof=True`
+            if as_oof:
+                raise NotImplementedError('inferred_groups not implemented when as_oof=True')
             self._val_thresholds = np.asarray(inferred_groups.predict_proba(self.validation_data))
         else:
             # Use OneHot and store encoder so it will work on new data
@@ -72,7 +101,6 @@ class FairPredictor:
             self._val_thresholds = self.group_encoder.transform(
                 self._internal_groups.reshape(-1, 1)).toarray()
 
-        self.proba = np.asarray(predictor.predict_proba(self.validation_data))
         self.y_true = np.asarray(validation_labels == self.predictor.class_labels[1])
         self.frontier = None
         if self.use_fast:
@@ -318,6 +346,7 @@ class FairPredictor:
             plt.legend(loc='best')
         else:
             plt.scatter(front2, front1, c=color)
+        plt.show()
             
     def evaluate(self, data=None, metrics=None, verbose=False) -> pd.DataFrame:
         """Compute standard metrics of the original predictor and the updated predictor

--- a/src/autogluon/fair/learners/fair.py
+++ b/src/autogluon/fair/learners/fair.py
@@ -83,7 +83,7 @@ class FairPredictor:
 
         # We use _internal_groups as a standardized argument that is always safe to pass
         # to functions expecting a vector
-        self._internal_groups = self.groups_to_numpy(groups, validation_data)
+        self._internal_groups = self.groups_to_numpy(groups, self.validation_data)
 
         if self._internal_groups.shape[0] != validation_labels.shape[0]:
             logger.error('The size of the groups does not match the dataset size')
@@ -346,7 +346,6 @@ class FairPredictor:
             plt.legend(loc='best')
         else:
             plt.scatter(front2, front1, c=color)
-        plt.show()
             
     def evaluate(self, data=None, metrics=None, verbose=False) -> pd.DataFrame:
         """Compute standard metrics of the original predictor and the updated predictor


### PR DESCRIPTION
- Add as_oof init param
- This dramatically improves the correctness and informativeness of the fairness performance tradeoff
- When bagging is enabled, this comes at 0 cost to sample size (free major improvement)


Example script:

```python3

# Load and train a baseline classifier

from autogluon.tabular import TabularDataset, TabularPredictor
from autogluon.fair import FairPredictor 
from autogluon.fair.utils import group_metrics as gm
train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
test_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')
predictor = TabularPredictor(label='class').fit(train_data=train_data)
```

```python3
predictor.leaderboard()
```

```
                  model  score_val  pred_time_val   fit_time  pred_time_val_marginal  fit_time_marginal  stack_level  can_infer  fit_order
0   WeightedEnsemble_L2     0.8912       0.099142   8.798374                0.004605           1.105777            2       True         14
1               XGBoost     0.8872       0.022041   1.895144                0.022041           1.895144            1       True         11
2         LightGBMLarge     0.8856       0.022847   0.951653                0.022847           0.951653            1       True         13
3              CatBoost     0.8824       0.013061   4.616093                0.013061           4.616093            1       True          7
4              LightGBM     0.8824       0.016489   0.460558                0.016489           0.460558            1       True          4
5            LightGBMXT     0.8792       0.021510   1.237471                0.021510           1.237471            1       True          3
6      RandomForestEntr     0.8624       0.076648   2.598845                0.076648           2.598845            1       True          6
7       NeuralNetFastAI     0.8616       0.041444  31.895101                0.041444          31.895101            1       True         10
8      RandomForestGini     0.8600       0.114874   1.845957                0.114874           1.845957            1       True          5
9        NeuralNetTorch     0.8588       0.021620  34.150226                0.021620          34.150226            1       True         12
10       ExtraTreesGini     0.8500       0.083104   1.116725                0.083104           1.116725            1       True          8
11       ExtraTreesEntr     0.8456       0.082115   1.132972                0.082115           1.132972            1       True          9
12       KNeighborsUnif     0.7752       0.011650   3.147771                0.011650           3.147771            1       True          1
13       KNeighborsDist     0.7660       0.013648   0.018692                0.013648           0.018692            1       True          2
```


```python3
# not overfit
fpredictor_new = FairPredictor(predictor, train_data, 'sex', as_oof=True)
fpredictor_new.fit(gm.accuracy, gm.demographic_parity, 0.02)
fpredictor_new.plot_frontier()
```

![myplot1](https://user-images.githubusercontent.com/16392542/222044120-0f7e2ee0-0810-4eba-9af4-42ca91bc36b4.png)

```python3
# overfit
fpredictor_old = FairPredictor(predictor, train_data, 'sex')
fpredictor_old.fit(gm.accuracy, gm.demographic_parity, 0.02)
fpredictor_old.plot_frontier()
```

![myplot2](https://user-images.githubusercontent.com/16392542/222044198-5c2b13e4-8b68-491f-b42a-24568c6368bb.png)

